### PR TITLE
Improve loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,17 +3,21 @@ Some code which blocks some of the adware that is affecting gmod
 
 
 This blocks against
-  - Zhroms Prop Pack
-  - G-Realms
-  - Star Wars Aliens Pack
-  - Nox Networks
-  - Phenomenal Nation
+	- Zhroms Prop Pack
+	- G-Realms
+	- Star Wars Aliens Pack
+	- Nox Networks
+	- Phenomenal Nation
   
 Credits
-  - StarLight (base code)
-  - Doctor (finding addons)
-  - Vaas (finding addons)
-
+	- StarLight (base code)
+	- Nicolas (wrote code to block based on workshop id)
+	- Nykez (some dynamic data loading)
+	- Luiggi33 (fixed Steam HTTP not loaded Error)
+	- Herminatar (icon base)
+	- The Doctor (finding addons)
+	- Vaas (finding addons)
+	- woha (finding addons)
 
 Addon will automatically update the blacklist as long as you're connected to the internet.
 

--- a/lua/autorun/sh_adblocker.lua
+++ b/lua/autorun/sh_adblocker.lua
@@ -212,7 +212,7 @@ if (!Initial_Load) then
 
 	OverrideFunctions()
 
-	timer.Simple(4, function()
+	timer.Simple(0, function()
 		GetBlacklistData(function(results)
 			if (results) then
 				hookRemoverFunc()
@@ -224,17 +224,5 @@ if (!Initial_Load) then
 	
 			InjectAddons(true)
 		end)
-	end)
-	
-	GetBlacklistData(function(results)
-		if (results) then
-			hookRemoverFunc()
-		else
-			-- couldn't get new data, fallback to hard storage.
-			print("[Adware Block] Failed to get blacklist github data. Using hard-storage (maybe out of date)")
-			ReadHardStorage()
-		end
-
-		InjectAddons(true)
 	end)
 end

--- a/lua/autorun/sh_adblocker.lua
+++ b/lua/autorun/sh_adblocker.lua
@@ -1,7 +1,7 @@
+SL__AD_BLOCKER_Initial_Load = SL__AD_BLOCKER_Initial_Load or false
 
 local TimerTime = 20
 local MAX_TRY = 3
-local Initial_Load = Initial_Load or false
 local data = data or {}
 
 local RAW_URL = "https://github.com/StarLight-Oliver/Adware-blocker-gmod/raw/master/data/adware_block/data.json"
@@ -207,21 +207,21 @@ local OverrideFunctions = function()
 end
 
 
-if (!Initial_Load) then
+if (!SL__AD_BLOCKER_Initial_Load) then
 	ReadHardStorage()
-
 	OverrideFunctions()
+	hookRemoverFunc()
 
 	timer.Simple(0, function()
 		GetBlacklistData(function(results)
 			if (results) then
-				hookRemoverFunc()
 			else
 				-- couldn't get new data, fallback to hard storage.
 				print("[Adware Block] Failed to get blacklist github data. Using hard-storage (maybe out of date)")
 				ReadHardStorage()
 			end
-	
+			
+			hookRemoverFunc()
 			InjectAddons(true)
 		end)
 	end)


### PR DESCRIPTION
This should stop the `HTTP failed` error from happening. This is caused by the http module not begin loaded on the first "tick", that is why a `timer.Simple(0,` is needed